### PR TITLE
json 핸들링 유틸 추가

### DIFF
--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/client/HttpClient.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/client/HttpClient.kt
@@ -18,6 +18,8 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import timber.log.Timber
@@ -54,4 +56,8 @@ private val KtorClient =
 public object HttpClientProvider {
   @Provides
   public fun ktorClient(): HttpClient = KtorClient
+}
+
+internal fun HttpRequestBuilder.jsonBody(pretty: Boolean = false, builder: JsonBuilder.() -> Unit) {
+  setBody(buildJson(pretty, builder))
 }

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/client/json.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/client/json.kt
@@ -1,0 +1,115 @@
+/*
+ * Designed and developed by Wedemy 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/Wedemy/eggeum-android/blob/main/LICENSE
+ */
+
+package us.wedemy.eggeum.android.data.client
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonWriter
+import okio.Buffer
+import us.wedemy.eggeum.android.domain.EggeumDsl
+
+@EggeumDsl
+internal interface JsonBuilder {
+  infix fun String.withInt(value: Int?)
+  infix fun String.withFloat(value: Float?)
+  infix fun String.withBoolean(value: Boolean?)
+  infix fun String.withString(value: String?)
+  fun <T> String.withPojo(adapter: JsonAdapter<T>, value: T?)
+
+  infix fun String.withInts(value: List<Int>)
+  infix fun String.withFloats(value: List<Float>)
+  infix fun String.withBooleans(value: List<Boolean>)
+  infix fun String.withStrings(value: List<String>)
+  fun <T> String.withPojos(adapter: JsonAdapter<List<T?>>, value: List<T?>?)
+
+  fun build(): String
+}
+
+// 매 DSL 마다 `builder` 인스턴스를 새로 만들어야 함
+// -> 싱글톤 불가
+internal class JsonBuilderInstance(private val pretty: Boolean) : JsonBuilder {
+  private val buffer = Buffer()
+  private val writer =
+    JsonWriter
+      .of(buffer)
+      .apply {
+        if (pretty) indent = "  "
+        serializeNulls = true
+      }
+      .also { it.beginObject() }
+
+  override fun String.withInt(value: Int?) {
+    writer.name(this).value(value)
+  }
+
+  override fun String.withFloat(value: Float?) {
+    writer.name(this).value(value)
+  }
+
+  override fun String.withBoolean(value: Boolean?) {
+    writer.name(this).value(value)
+  }
+
+  override fun String.withString(value: String?) {
+    writer.name(this).value(value)
+  }
+
+  override fun <T> String.withPojo(adapter: JsonAdapter<T>, value: T?) {
+    writer.name(this)
+    adapter.serializeNulls().toJson(writer, value)
+  }
+
+  override fun String.withInts(value: List<Int>) {
+    writer.name(this)
+    writer.beginArray()
+    for (element in value) {
+      writer.value(element)
+    }
+    writer.endArray()
+  }
+
+  override fun String.withFloats(value: List<Float>) {
+    writer.name(this)
+    writer.beginArray()
+    for (element in value) {
+      writer.value(element)
+    }
+    writer.endArray()
+  }
+
+  override fun String.withBooleans(value: List<Boolean>) {
+    writer.name(this)
+    writer.beginArray()
+    for (element in value) {
+      writer.value(element)
+    }
+    writer.endArray()
+  }
+
+  override fun String.withStrings(value: List<String>) {
+    writer.name(this)
+    writer.beginArray()
+    for (element in value) {
+      writer.value(element)
+    }
+    writer.endArray()
+  }
+
+  override fun <T> String.withPojos(adapter: JsonAdapter<List<T?>>, value: List<T?>?) {
+    writer.name(this)
+    adapter.serializeNulls().toJson(writer, value)
+  }
+
+  // https://github.com/JakeWharton/asciinema-vsync/blob/17ae722af6848aca41ce2964ad835cb1455dd13d/src/main/kotlin/com/jakewharton/asciinema/vsync/asciinemaVsync.kt#L24
+  override fun build(): String {
+    writer.endObject().close()
+    return buffer.readUtf8()
+  }
+}
+
+internal inline fun buildJson(pretty: Boolean = false, builder: JsonBuilder.() -> Unit) =
+  with(JsonBuilderInstance(pretty)) { builder(); build() }

--- a/data/src/test/kotlin/us/wedemy/eggeum/android/data/JsonBuilderTest.kt
+++ b/data/src/test/kotlin/us/wedemy/eggeum/android/data/JsonBuilderTest.kt
@@ -1,0 +1,252 @@
+/*
+ * Designed and developed by Wedemy 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/Wedemy/eggeum-android/blob/main/LICENSE
+ */
+
+package us.wedemy.eggeum.android.data
+
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import us.wedemy.eggeum.android.data.client.buildJson
+
+@JsonClass(generateAdapter = true)
+data class Pojo(
+  val string: String?,
+  val list: List<Any>?,
+  val nested: Pojo? = null,
+)
+
+class JsonBuilderTest : FreeSpec() {
+  private val moshi = Moshi.Builder().build()
+
+  init {
+    "pretty" - {
+      "single json" {
+        val actual =
+          buildJson(pretty = true) {
+            "int" withInt 1
+            "float" withFloat 1f
+            "boolean" withBoolean true
+            "string" withString "string"
+            "pojo".withPojo(moshi.adapter(), Pojo("1", listOf("2")))
+          }
+        val expected =
+          "{\n" +
+            "  \"int\": 1,\n" +
+            "  \"float\": 1.0,\n" +
+            "  \"boolean\": true,\n" +
+            "  \"string\": \"string\",\n" +
+            "  \"pojo\": {\n" +
+            "    \"string\": \"1\",\n" +
+            "    \"list\": [\n" +
+            "      \"2\"\n" +
+            "    ],\n" +
+            "    \"nested\": null\n" +
+            "  }\n" +
+            "}"
+
+        actual shouldBe expected
+      }
+
+      "double json" {
+        val actual =
+          buildJson(pretty = true) {
+            "ints" withInts listOf(1, 2)
+            "floats" withFloats listOf(1f, 2f)
+            "booleans" withBooleans listOf(true, false)
+            "strings" withStrings listOf("string", "string2")
+            "pojos"
+              .withPojos(
+                moshi.adapter(Types.newParameterizedType(List::class.java, Pojo::class.java)),
+                listOf(
+                  Pojo("1", listOf("2")),
+                  Pojo("3", listOf("4")),
+                ),
+              )
+          }
+        val expected =
+          "{\n" +
+            "  \"ints\": [\n" +
+            "    1,\n" +
+            "    2\n" +
+            "  ],\n" +
+            "  \"floats\": [\n" +
+            "    1.0,\n" +
+            "    2.0\n" +
+            "  ],\n" +
+            "  \"booleans\": [\n" +
+            "    true,\n" +
+            "    false\n" +
+            "  ],\n" +
+            "  \"strings\": [\n" +
+            "    \"string\",\n" +
+            "    \"string2\"\n" +
+            "  ],\n" +
+            "  \"pojos\": [\n" +
+            "    {\n" +
+            "      \"string\": \"1\",\n" +
+            "      \"list\": [\n" +
+            "        \"2\"\n" +
+            "      ],\n" +
+            "      \"nested\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"string\": \"3\",\n" +
+            "      \"list\": [\n" +
+            "        \"4\"\n" +
+            "      ],\n" +
+            "      \"nested\": null\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}"
+
+        actual shouldBe expected
+      }
+
+      "nested pojo json" {
+        val actual =
+          buildJson(pretty = true) {
+            "int" withInt 1
+            "float" withFloat 1f
+            "boolean" withBoolean true
+            "string" withString "string"
+            "pojo"
+              .withPojo(
+                moshi.adapter(),
+                Pojo(
+                  "1",
+                  listOf("2"),
+                  Pojo(
+                    "3",
+                    listOf("4"),
+                  ),
+                ),
+              )
+          }
+        val expected =
+          "{\n" +
+            "  \"int\": 1,\n" +
+            "  \"float\": 1.0,\n" +
+            "  \"boolean\": true,\n" +
+            "  \"string\": \"string\",\n" +
+            "  \"pojo\": {\n" +
+            "    \"string\": \"1\",\n" +
+            "    \"list\": [\n" +
+            "      \"2\"\n" +
+            "    ],\n" +
+            "    \"nested\": {\n" +
+            "      \"string\": \"3\",\n" +
+            "      \"list\": [\n" +
+            "        \"4\"\n" +
+            "      ],\n" +
+            "      \"nested\": null\n" +
+            "    }\n" +
+            "  }\n" +
+            "}"
+
+        actual shouldBe expected
+      }
+    }
+
+    "unpretty" - {
+      "single json" {
+        val actual =
+          buildJson(pretty = false) {
+            "int" withInt 1
+            "float" withFloat 1f
+            "boolean" withBoolean true
+            "string" withString "string"
+            "pojo".withPojo(moshi.adapter(), Pojo("1", listOf("2")))
+          }
+        val expected =
+          "{" +
+            "\"int\":1," +
+            "\"float\":1.0," +
+            "\"boolean\":true," +
+            "\"string\":\"string\"," +
+            "\"pojo\":{\"string\":\"1\",\"list\":[\"2\"]," +
+            "\"nested\":null}" +
+            "}"
+
+        actual shouldBe expected
+      }
+
+      "double json" {
+        val actual =
+          buildJson(pretty = false) {
+            "ints" withInts listOf(1, 2)
+            "floats" withFloats listOf(1f, 2f)
+            "booleans" withBooleans listOf(true, false)
+            "strings" withStrings listOf("string", "string2")
+            "pojos"
+              .withPojos(
+                moshi.adapter(Types.newParameterizedType(List::class.java, Pojo::class.java)),
+                listOf(
+                  Pojo("1", listOf("2")),
+                  Pojo("3", listOf("4")),
+                ),
+              )
+          }
+        val expected =
+          "{" +
+            "\"ints\":[1,2]," +
+            "\"floats\":[1.0,2.0]," +
+            "\"booleans\":[true,false]," +
+            "\"strings\":[\"string\",\"string2\"]," +
+            "\"pojos\":[" +
+            "{\"string\":\"1\",\"list\":[\"2\"],\"nested\":null}," +
+            "{\"string\":\"3\",\"list\":[\"4\"],\"nested\":null}" +
+            "]" +
+            "}"
+
+        actual shouldBe expected
+      }
+
+      "nested pojo json" {
+        val actual =
+          buildJson(pretty = false) {
+            "int" withInt 1
+            "float" withFloat 1f
+            "boolean" withBoolean true
+            "string" withString "string"
+            "pojo"
+              .withPojo(
+                moshi.adapter(),
+                Pojo(
+                  "1",
+                  listOf("2"),
+                  Pojo(
+                    "3",
+                    listOf("4"),
+                  ),
+                ),
+              )
+          }
+        val expected =
+          "{" +
+            "\"int\":1," +
+            "\"float\":1.0," +
+            "\"boolean\":true," +
+            "\"string\":\"string\"," +
+            "\"pojo\":{" +
+            "\"string\":\"1\"," +
+            "\"list\":[\"2\"]," +
+            "\"nested\":{" +
+            "\"string\":\"3\"," +
+            "\"list\":[\"4\"]," +
+            "\"nested\":null" +
+            "}" +
+            "}" +
+            "}"
+
+        actual shouldBe expected
+      }
+    }
+  }
+}

--- a/data/src/test/kotlin/us/wedemy/eggeum/android/data/repository/NoticeTest.kt
+++ b/data/src/test/kotlin/us/wedemy/eggeum/android/data/repository/NoticeTest.kt
@@ -5,7 +5,7 @@
  * Please see full license: https://github.com/Wedemy/eggeum-android/blob/main/LICENSE
  */
 
-package us.wedemy.eggeum.android.data
+package us.wedemy.eggeum.android.data.repository
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -16,7 +16,6 @@ import io.ktor.client.engine.mock.respondOk
 import io.ktor.http.fullPath
 import org.intellij.lang.annotations.Language
 import us.wedemy.eggeum.android.data.client.MoshiProvider
-import us.wedemy.eggeum.android.data.repository.NoticeRepositoryProvider
 import us.wedemy.eggeum.android.domain.model.notice.NoticeBody
 import us.wedemy.eggeum.android.domain.model.notice.NoticeList
 import us.wedemy.eggeum.android.domain.repository.NoticeRepository
@@ -93,7 +92,16 @@ class NoticeTest : StringSpec() {
     }
 
     "list" {
-      val actual = repository.getNoticeList()
+      val actual =
+        repository
+          .getNoticeList(
+            search = null,
+            page = null,
+            size = null,
+            sort = null,
+            startDate = null,
+            endDate = null,
+          )
       val expect =
         NoticeList(
           elements = listOf(

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/EggeumDsl.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/EggeumDsl.kt
@@ -1,0 +1,11 @@
+/*
+ * Designed and developed by Wedemy 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/Wedemy/eggeum-android/blob/main/LICENSE
+ */
+
+package us.wedemy.eggeum.android.domain
+
+@DslMarker
+public annotation class EggeumDsl


### PR DESCRIPTION
## Overview (Required)

- key-value로 json string을 생성할 수 있는 `jsonBuilder` 확장 함수를 추가합니다.
- key-value json을 body로 설정하는 `jsonBody` 확장 함수를 추가합니다.
