### PR TITLE
hilt ksp migration

### DIFF
--- a/build-logic/src/main/kotlin/build-logics.kt
+++ b/build-logic/src/main/kotlin/build-logics.kt
@@ -72,9 +72,9 @@ internal class AndroidLibraryPlugin : BuildLogicPlugin({
 internal class AndroidHiltPlugin : BuildLogicPlugin({
   applyPlugins(
     libs.findPlugin("android-hilt").get().get().pluginId,
-    Plugins.KotlinKapt,
+    Plugins.Ksp,
   )
-  dependencies.add("kapt", libs.findLibrary("android-hilt-compile").get())
+  dependencies.add("ksp", libs.findLibrary("android-hilt-compile").get())
   dependencies.add("implementation", libs.findLibrary("android-hilt-runtime").get())
 })
 

--- a/build-logic/src/main/kotlin/plugins.kt
+++ b/build-logic/src/main/kotlin/plugins.kt
@@ -10,8 +10,9 @@ internal object Plugins {
 
   const val KotlinJvm = "org.jetbrains.kotlin.jvm"
   const val KotlinAndroid = "org.jetbrains.kotlin.android"
-  const val KotlinKapt = "org.jetbrains.kotlin.kapt"
 
   const val AndroidApplication = "com.android.application"
   const val AndroidLibrary = "com.android.library"
+
+  const val Ksp = "com.google.devtools.ksp"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
   alias(libs.plugins.gradle.android.library) apply false
   alias(libs.plugins.google.secrets) apply false
   alias(libs.plugins.android.hilt) apply false
+  alias(libs.plugins.ksp) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ lottie = "6.1.0"
 insetter = "0.6.1"
 timber = "5.0.1"
 naver-map = "3.17.0"
+ksp = "1.8.22-1.0.11"
 
 javax-inject = "1"
 
@@ -64,6 +65,7 @@ android-hilt = { id = "com.google.dagger.hilt.android", version.ref = "android-h
 androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidx-navigation" }
 
 moshix-ir = { id = "dev.zacsweers.moshix", version.ref = "moshix-ir" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 test-roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "test-roborazzi" }
 


### PR DESCRIPTION
hilt version 2.48 version에서 ksp 를 지원하게 되어 기존의 kapt 를 ksp 로 migration

