### PR TITLE
Authenticator Retry 로직 수정 및 토큰 관리, 에러 처리 보완

### DIFF
--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/datasource/login/LoginLocalDataSourceImpl.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/datasource/login/LoginLocalDataSourceImpl.kt
@@ -11,7 +11,6 @@ import javax.inject.Inject
 import us.wedemy.eggeum.android.data.datastore.TokenDataStoreProvider
 
 public class LoginLocalDataSourceImpl @Inject constructor(
-  // private val dataStore: TokenDataStore
   private val dataStore: TokenDataStoreProvider,
 ) : LoginLocalDataSource {
   override suspend fun setAccessToken(accessToken: String) {

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/extensions/Exception.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/extensions/Exception.kt
@@ -7,6 +7,7 @@
 
 package us.wedemy.eggeum.android.data.extensions
 
+import java.io.IOException
 import java.net.UnknownHostException
 import retrofit2.HttpException
 
@@ -14,6 +15,7 @@ internal fun Exception.toAlertMessage(): String {
   return when (this) {
     is HttpException -> "서버에 문제가 발생했어요. 잠시 후 다시 시도해주세요."
     is UnknownHostException -> "네트워크 연결을 확인해주세요."
+    is IOException -> "로그인 토큰이 만료되었어요. 다시 로그인 해주세요"
     else -> "예기치 못한 오류가 발생했어요. 잠시 후 다시 시도해주세요."
   }
 }

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/service/LoginService.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/service/LoginService.kt
@@ -9,7 +9,6 @@ package us.wedemy.eggeum.android.data.service
 
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.GET
 import retrofit2.http.POST
 import us.wedemy.eggeum.android.data.model.login.LoginRequest
 import us.wedemy.eggeum.android.data.model.login.LoginResponse
@@ -23,7 +22,7 @@ public interface LoginService {
     @Body loginRequest: LoginRequest,
   ): Response<LoginResponse>
 
-  @GET("app/sns-sign-up")
+  @POST("app/sns-sign-up")
   public suspend fun signUp(
     @Body signUpRequest: SignUpRequest,
   ): Response<SignUpResponse>

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/service/TokenAuthenticator.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/service/TokenAuthenticator.kt
@@ -1,43 +1,23 @@
 package us.wedemy.eggeum.android.data.service
 
+import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
-import javax.inject.Inject
 import us.wedemy.eggeum.android.data.datastore.TokenDataStoreProvider
 
 public class TokenAuthenticator @Inject constructor(
   private val dataStoreProvider: TokenDataStoreProvider,
 ) : Authenticator {
 
-  override fun authenticate(route: Route?, response: Response): Request? {
-    val accessToken = runBlocking {
-      dataStoreProvider.getAccessToken()
+  override fun authenticate(route: Route?, response: Response): Request {
+    synchronized(this) {
+      val newAccessToken = runBlocking { dataStoreProvider.getRefreshToken() }
+      return newRequestWithAccessToken(response.request, newAccessToken)
     }
-
-    if (hasNotAccessTokenOnResponse(response)) {
-      synchronized(this) {
-        val newAccessToken = runBlocking {
-          dataStoreProvider.getAccessToken()
-        }
-        if (accessToken != newAccessToken) {
-          return newRequestWithAccessToken(response.request, newAccessToken)
-        }
-
-        val refreshToken = runBlocking {
-          dataStoreProvider.getRefreshToken()
-        }
-        return newRequestWithAccessToken(response.request, refreshToken)
-      }
-    }
-
-    return null
   }
-
-  private fun hasNotAccessTokenOnResponse(response: Response): Boolean =
-    response.header("Authorization") == null
 
   private fun newRequestWithAccessToken(request: Request, accessToken: String): Request =
     request.newBuilder()

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/service/TokenAuthenticator.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/service/TokenAuthenticator.kt
@@ -6,16 +6,32 @@ import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
+import retrofit2.HttpException
 import us.wedemy.eggeum.android.data.datastore.TokenDataStoreProvider
+import us.wedemy.eggeum.android.domain.util.RefreshTokenExpiredException
 
+@Suppress("TooGenericExceptionCaught")
 public class TokenAuthenticator @Inject constructor(
   private val dataStoreProvider: TokenDataStoreProvider,
 ) : Authenticator {
 
   override fun authenticate(route: Route?, response: Response): Request {
     synchronized(this) {
-      val newAccessToken = runBlocking { dataStoreProvider.getRefreshToken() }
-      return newRequestWithAccessToken(response.request, newAccessToken)
+      try {
+        val newAccessToken = runBlocking { dataStoreProvider.getRefreshToken() }
+        return newRequestWithAccessToken(response.request, newAccessToken)
+      } catch (e: Exception) {
+        when(e) {
+          is HttpException -> {
+            if (e.code() == 401) {
+              throw RefreshTokenExpiredException
+            } else {
+              throw e
+            }
+          }
+          else -> throw e
+        }
+      }
     }
   }
 

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/util/safeRequest.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/util/safeRequest.kt
@@ -13,6 +13,7 @@ import retrofit2.HttpException
 import retrofit2.Response
 import us.wedemy.eggeum.android.data.extensions.toAlertMessage
 
+@Suppress("TooGenericExceptionCaught")
 internal suspend fun <T> safeRequest(request: suspend () -> Response<T>): T? {
   try {
     val response = request()
@@ -38,6 +39,11 @@ internal suspend fun <T> safeRequest(request: suspend () -> Response<T>): T? {
       cause = exception,
     )
   } catch (exception: IOException) {
+    throw ExceptionWrapper(
+      message = exception.toAlertMessage(),
+      cause = exception,
+    )
+  } catch (exception: Exception) {
     throw ExceptionWrapper(
       message = exception.toAlertMessage(),
       cause = exception,

--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/util/safeRequest.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/util/safeRequest.kt
@@ -7,13 +7,12 @@
 
 package us.wedemy.eggeum.android.data.util
 
+import java.io.IOException
 import java.net.UnknownHostException
 import retrofit2.HttpException
 import retrofit2.Response
-import timber.log.Timber
 import us.wedemy.eggeum.android.data.extensions.toAlertMessage
 
-@Suppress("TooGenericExceptionCaught")
 internal suspend fun <T> safeRequest(request: suspend () -> Response<T>): T? {
   try {
     val response = request()
@@ -21,7 +20,6 @@ internal suspend fun <T> safeRequest(request: suspend () -> Response<T>): T? {
       return response.body()
     } else {
       val errorBody = response.errorBody()?.string() ?: "Unknown error"
-      Timber.d(Exception(errorBody))
       throw ExceptionWrapper(
         statusCode = response.code(),
         message = Exception(errorBody).toAlertMessage(),
@@ -29,20 +27,17 @@ internal suspend fun <T> safeRequest(request: suspend () -> Response<T>): T? {
       )
     }
   } catch (exception: HttpException) {
-    Timber.d(exception)
     throw ExceptionWrapper(
       statusCode = exception.code(),
       message = exception.response()?.errorBody()?.string() ?: exception.message(),
       cause = exception,
     )
   } catch (exception: UnknownHostException) {
-    Timber.d(exception)
     throw ExceptionWrapper(
       message = exception.toAlertMessage(),
       cause = exception,
     )
-  } catch (exception: Exception) {
-    Timber.d(exception)
+  } catch (exception: IOException) {
     throw ExceptionWrapper(
       message = exception.toAlertMessage(),
       cause = exception,

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/util/Exceptions.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/util/Exceptions.kt
@@ -13,6 +13,7 @@ import java.io.IOException
 public val LoginApiResponseIsNull: IOException = IOException("Login API response is null.")
 public val LoginApiResponseNotFound: IOException = IOException("Login API returned Not Found.")
 public val SignUpApiResponseIsNull: IOException = IOException("SignUp API response is null.")
+public val RefreshTokenExpiredException: IOException = IOException("Refresh token is expired.")
 
 // Enum
 public val EnumApiResponseIsNull: IOException = IOException("The Enum API response is null.")

--- a/login/src/main/kotlin/us/wedemy/eggeum/android/login/LoginViewModel.kt
+++ b/login/src/main/kotlin/us/wedemy/eggeum/android/login/LoginViewModel.kt
@@ -54,10 +54,12 @@ class LoginViewModel @Inject constructor(
         result.isFailure -> {
           val exception = result.exceptionOrNull()
           Timber.d(exception)
-          if (exception == LoginApiResponseNotFound) {
-            _navigateToOnBoardingEvent.emit(Unit)
-          } else {
-            _showToastEvent.emit(exception?.message ?: "Unknown Error Occured")
+          if (exception != null) {
+            if (exception.cause == LoginApiResponseNotFound) {
+              _navigateToOnBoardingEvent.emit(Unit)
+            } else {
+              _showToastEvent.emit(exception.message ?: "Unknown Error Occured")
+            }
           }
         }
       }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/myaccount/MyAccountFragment.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/myaccount/MyAccountFragment.kt
@@ -21,6 +21,7 @@ import us.wedemy.eggeum.android.common.ui.BaseFragment
 import us.wedemy.eggeum.android.design.R
 import us.wedemy.eggeum.android.main.databinding.FragmentMyAccountBinding
 import us.wedemy.eggeum.android.main.model.UserInfoModel
+import us.wedemy.eggeum.android.main.ui.MainActivity
 import us.wedemy.eggeum.android.main.viewmodel.MyAccountViewModel
 
 @AndroidEntryPoint
@@ -80,6 +81,12 @@ class MyAccountFragment : BaseFragment<FragmentMyAccountBinding>() {
       launch {
         viewModel.showToastEvent.collect { message ->
           Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+        }
+      }
+
+      launch {
+        viewModel.navigateToLoginEvent.collect {
+          (activity as MainActivity).navigateToLogin()
         }
       }
     }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/WithdrawViewModel.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/WithdrawViewModel.kt
@@ -18,11 +18,13 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import us.wedemy.eggeum.android.common.util.getMutableStateFlow
+import us.wedemy.eggeum.android.domain.usecase.LogoutUseCase
 import us.wedemy.eggeum.android.domain.usecase.WithdrawUseCase
 
 @HiltViewModel
 class WithdrawViewModel @Inject constructor(
   private val withdrawUseCase: WithdrawUseCase,
+  private val logoutUseCase: LogoutUseCase,
   savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
   private val _agreeToWithdraw = savedStateHandle.getMutableStateFlow(KEY_AGREE_TO_NOTIFICATION, false)
@@ -43,6 +45,7 @@ class WithdrawViewModel @Inject constructor(
       val result = withdrawUseCase()
       when {
         result.isSuccess -> {
+          logoutUseCase()
           _navigateToLoginEvent.emit(Unit)
         }
         result.isFailure -> {


### PR DESCRIPTION
- Authenticator Retry 로직 수정
- 토큰이 만료된 경우 401 로 정상적으로 내려오는 것을 확인
- 회원 탈퇴를 수행할 경우, 저장된 로그인 토큰을 제거
- 회원 가입 API @POST 로 변경(@GET 으로 잘 못 설정되어 있었음)

TODO) AccessToken 과 RefreshToken 의 유효기간은 각각 1시간, 30일임, 이론상 30일 동안은 401이 뜨면 안되는데 현재는 짧은 시간 내에 401이 뜨는 것을 확인할 수 있음 -> RefreshToken 으로 정상적으로 갈아 끼워져 재시도가 수행되는지 다시 한번 확인해봐야 함

TODO) safeRequest 에러 핸들링 함수 개선 필요

TODO) Flow 타입을 반환하는 경우에도 RefreshTokenExpiredException을 반환하는 로직을 추가해야 함