### PR TITLE
카페 검색 화면내에 최근 검색 목록과 검색 결과 케이스를 분리   

### DIFF
--- a/data/src/main/kotlin/us/wedemy/eggeum/android/data/mapper/PlaceMapper.kt
+++ b/data/src/main/kotlin/us/wedemy/eggeum/android/data/mapper/PlaceMapper.kt
@@ -32,6 +32,7 @@ internal fun PlaceResponse.toEntity() =
     menu = menu?.toEntity(),
     name = name,
     type = type,
+    isRecentSearch = false,
   )
 
 internal fun PlaceEntity.toModel() =

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/ImageEntity.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/ImageEntity.kt
@@ -11,14 +11,4 @@ import us.wedemy.eggeum.android.domain.model.FileEntity
 
 public data class ImageEntity(
   val files: List<FileEntity>?,
-) {
-  public companion object {
-    public fun of(
-      files: List<FileEntity>? = null,
-    ): ImageEntity {
-      return ImageEntity(
-        files = files,
-      )
-    }
-  }
-}
+)

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/InfoEntity.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/InfoEntity.kt
@@ -23,42 +23,4 @@ public data class InfoEntity(
   val restRoom: String?,
   val singleSeatCount: Int?,
   val websiteUri: String?,
-) {
-  public companion object {
-    public fun of(
-      areaSize: String? = null,
-      blogUri: String? = null,
-      businessHours: List<String>? = null,
-      existsSmokingArea: Boolean? = null,
-      existsWifi: Boolean? = null,
-      existsOutlet: Boolean? = null,
-      instagramUri: String? = null,
-      meetingRoomCount: Int? = null,
-      mobileCharging: String? = null,
-      multiSeatCount: Int? = null,
-      parking: String? = null,
-      phone: String? = null,
-      restRoom: String? = null,
-      singleSeatCount: Int? = null,
-      websiteUri: String? = null,
-    ): InfoEntity {
-      return InfoEntity(
-        areaSize = areaSize,
-        blogUri = blogUri,
-        businessHours = businessHours,
-        existsSmokingArea = existsSmokingArea,
-        existsWifi = existsWifi,
-        existsOutlet = existsOutlet,
-        instagramUri = instagramUri,
-        meetingRoomCount = meetingRoomCount,
-        mobileCharging = mobileCharging,
-        multiSeatCount = multiSeatCount,
-        parking = parking,
-        phone = phone,
-        restRoom = restRoom,
-        singleSeatCount = singleSeatCount,
-        websiteUri = websiteUri,
-      )
-    }
-  }
-}
+)

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/MenuEntity.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/MenuEntity.kt
@@ -9,14 +9,4 @@ package us.wedemy.eggeum.android.domain.model.place
 
 public data class MenuEntity(
   var products: List<ProductEntity>?,
-) {
-  public companion object {
-    public fun of(
-      products: List<ProductEntity>? = null,
-    ): MenuEntity {
-      return MenuEntity(
-        products = products,
-      )
-    }
-  }
-}
+)

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/PlaceEntity.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/PlaceEntity.kt
@@ -18,6 +18,7 @@ public data class PlaceEntity(
   val menu: MenuEntity?,
   val name: String,
   val type: String?,
+  val isRecentSearch: Boolean,
 ) {
   public fun toUpsertPlaceEntity(): UpsertPlaceEntity {
     return UpsertPlaceEntity(

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/PlaceEntity.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/PlaceEntity.kt
@@ -34,31 +34,4 @@ public data class PlaceEntity(
       type = type,
     )
   }
-  public companion object {
-    public fun of(
-      address1: String? = null,
-      address2: String? = null,
-      id: Long,
-      image: ImageEntity? = null,
-      info: InfoEntity? = null,
-      latitude: Double? = null,
-      longitude: Double? = null,
-      menu: MenuEntity? = null,
-      name: String,
-      type: String? = null,
-    ): PlaceEntity {
-      return PlaceEntity(
-        address1 = address1,
-        address2 = address2,
-        id = id,
-        image = image,
-        info = info,
-        latitude = latitude!!,
-        longitude = longitude!!,
-        menu = menu,
-        name = name,
-        type = type,
-      )
-    }
-  }
 }

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/UpsertPlaceEntity.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/model/place/UpsertPlaceEntity.kt
@@ -19,22 +19,4 @@ public data class UpsertPlaceEntity(
   val placeId: Long?,
   val remarks: String?,
   val type: String?,
-) {
-  public companion object {
-    public fun of(info: InfoEntity, placeId: Long, name: String?): UpsertPlaceEntity {
-      return UpsertPlaceEntity(
-        address1 = null,
-        address2 = null,
-        image = null,
-        info = info,
-        latitude = null,
-        longitude = null,
-        menu = null,
-        name = name,
-        placeId = placeId,
-        remarks = null,
-        type = null,
-      )
-    }
-  }
-}
+)

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/usecase/PlaceUseCase.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/usecase/PlaceUseCase.kt
@@ -50,11 +50,21 @@ public class GetPlaceListUseCase @Inject constructor(
 public class GetSearchPlaceListUseCase @Inject constructor(
   private val repository: PlaceRepository,
 ) {
-  public operator fun invoke(query: String? = null): Flow<PagingData<PlaceEntity>> {
+  public operator fun invoke(
+    query: String? = null,
+    distance: Double? = null,
+    latitude: Double? = null,
+    longitude: Double? = null,
+  ): Flow<PagingData<PlaceEntity>> {
     return if (query.isNullOrEmpty()) {
       repository.getRecentSearchPlaceList()
     } else {
-      repository.getPlaceList(search = query)
+      repository.getPlaceList(
+        search = query,
+        distance = distance,
+        latitude = latitude,
+        longitude = longitude,
+      )
     }
   }
 }

--- a/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/usecase/PlaceUseCase.kt
+++ b/domain/src/main/kotlin/us/wedemy/eggeum/android/domain/usecase/PlaceUseCase.kt
@@ -8,9 +8,11 @@
 package us.wedemy.eggeum.android.domain.usecase
 
 import androidx.paging.PagingData
+import androidx.paging.map
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import us.wedemy.eggeum.android.domain.model.place.PlaceEntity
 import us.wedemy.eggeum.android.domain.model.place.UpsertPlaceEntity
 import us.wedemy.eggeum.android.domain.repository.PlaceRepository
@@ -57,7 +59,11 @@ public class GetSearchPlaceListUseCase @Inject constructor(
     longitude: Double? = null,
   ): Flow<PagingData<PlaceEntity>> {
     return if (query.isNullOrEmpty()) {
-      repository.getRecentSearchPlaceList()
+      repository.getRecentSearchPlaceList().map { pagingData ->
+        pagingData.map { place ->
+          place.copy(isRecentSearch = true)
+        }
+      }
     } else {
       repository.getPlaceList(
         search = query,

--- a/login/src/main/AndroidManifest.xml
+++ b/login/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Designed and developed by Wedemy 2023.
   ~
   ~ Licensed under the MIT.
@@ -9,9 +8,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
+
     <activity
       android:name=".LoginActivity"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:theme="@style/Theme.Eggeum.Login" />
 
   </application>

--- a/main/src/main/AndroidManifest.xml
+++ b/main/src/main/AndroidManifest.xml
@@ -8,9 +8,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
+
     <activity
       android:name=".ui.MainActivity"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:theme="@style/Theme.Eggeum.Main"
       android:windowSoftInputMode="adjustResize" />
 

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/adapter/SearchCafeAdapter.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/adapter/SearchCafeAdapter.kt
@@ -11,31 +11,59 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
 import us.wedemy.eggeum.android.domain.model.place.PlaceEntity
-import us.wedemy.eggeum.android.main.databinding.ItemSearchCafeLocationBinding
+import us.wedemy.eggeum.android.main.databinding.ItemRecentSearchCafeResultBinding
+import us.wedemy.eggeum.android.main.databinding.ItemSearchCafeResultBinding
 import us.wedemy.eggeum.android.main.ui.adapter.listener.SearchCafeClickListener
+import us.wedemy.eggeum.android.main.ui.adapter.viewholder.RecentSearchCafeViewHolder
 import us.wedemy.eggeum.android.main.ui.adapter.viewholder.SearchCafeViewHolder
 
 class SearchCafeAdapter(private val clickListener: SearchCafeClickListener? = null) :
-  PagingDataAdapter<PlaceEntity, SearchCafeViewHolder>(PlaceEntityDiffCallback) {
+  PagingDataAdapter<PlaceEntity, RecyclerView.ViewHolder>(PlaceEntityDiffCallback) {
 
-  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
-    SearchCafeViewHolder(ItemSearchCafeLocationBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+  override fun getItemViewType(position: Int): Int {
+    return if (getItem(position)?.isRecentSearch == true) {
+      VIEW_TYPE_RECENT_SEARCH_CAFE
+    } else {
+      VIEW_TYPE_SEARCH_CAFE
+    }
+  }
 
-  override fun onBindViewHolder(holder: SearchCafeViewHolder, position: Int) {
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+    return when(viewType) {
+      VIEW_TYPE_SEARCH_CAFE -> SearchCafeViewHolder(
+        ItemSearchCafeResultBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+      )
+      VIEW_TYPE_RECENT_SEARCH_CAFE -> RecentSearchCafeViewHolder(
+        ItemRecentSearchCafeResultBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+      )
+      else -> throw IllegalStateException("Unknown viewType $viewType")
+    }
+  }
+
+  override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
     val cafeItem = getItem(position)
     cafeItem?.let { cafe ->
-      holder.bind(cafe)
-      holder.binding.root.setOnClickListener {
-        clickListener?.onItemSelected(cafeItem)
+      when (holder) {
+        is RecentSearchCafeViewHolder -> holder.bind(cafe)
+        is SearchCafeViewHolder -> holder.bind(cafe)
       }
-      holder.binding.ivCafeSearchLocationDelete.setOnClickListener {
-        clickListener?.onItemDeleteClick(cafeItem)
+      holder.itemView.setOnClickListener {
+        clickListener?.onItemSelected(cafe)
+      }
+      if (holder is RecentSearchCafeViewHolder) {
+        holder.binding.ivRecentSearchCafeDelete.setOnClickListener {
+          clickListener?.onItemDeleteClick(cafe)
+        }
       }
     }
   }
 
   companion object {
+    private const val VIEW_TYPE_RECENT_SEARCH_CAFE = 0
+    private const val VIEW_TYPE_SEARCH_CAFE = 1
+
     private val PlaceEntityDiffCallback = object : DiffUtil.ItemCallback<PlaceEntity>() {
       override fun areItemsTheSame(
         oldItem: PlaceEntity,

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/adapter/SearchCafeAdapter.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/adapter/SearchCafeAdapter.kt
@@ -31,14 +31,14 @@ class SearchCafeAdapter(private val clickListener: SearchCafeClickListener? = nu
   }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-    return when(viewType) {
+    return when (viewType) {
       VIEW_TYPE_SEARCH_CAFE -> SearchCafeViewHolder(
-        ItemSearchCafeResultBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        ItemSearchCafeResultBinding.inflate(LayoutInflater.from(parent.context), parent, false),
       )
       VIEW_TYPE_RECENT_SEARCH_CAFE -> RecentSearchCafeViewHolder(
-        ItemRecentSearchCafeResultBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        ItemRecentSearchCafeResultBinding.inflate(LayoutInflater.from(parent.context), parent, false),
       )
-      else -> throw IllegalStateException("Unknown viewType $viewType")
+      else -> error("Unknown viewType $viewType")
     }
   }
 

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/adapter/viewholder/RecentSearchCafeViewHolder.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/adapter/viewholder/RecentSearchCafeViewHolder.kt
@@ -9,15 +9,12 @@ package us.wedemy.eggeum.android.main.ui.adapter.viewholder
 
 import us.wedemy.eggeum.android.common.base.BaseViewHolder
 import us.wedemy.eggeum.android.domain.model.place.PlaceEntity
-import us.wedemy.eggeum.android.main.databinding.ItemSearchCafeResultBinding
+import us.wedemy.eggeum.android.main.databinding.ItemRecentSearchCafeResultBinding
 
-class SearchCafeViewHolder(binding: ItemSearchCafeResultBinding) :
-  BaseViewHolder<PlaceEntity, ItemSearchCafeResultBinding>(binding) {
+class RecentSearchCafeViewHolder(binding: ItemRecentSearchCafeResultBinding) :
+  BaseViewHolder<PlaceEntity, ItemRecentSearchCafeResultBinding>(binding) {
 
   override fun bind(item: PlaceEntity) {
-    binding.apply {
-      tvSearchCafeResultName.text = item.name
-      tvSearchCafeResultAddress.text = item.address1
-    }
+    binding.tvRecentSearchCafeName.text = item.name
   }
 }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/search/SearchCafeFragment.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/search/SearchCafeFragment.kt
@@ -91,17 +91,15 @@ class SearchCafeFragment : BaseFragment<FragmentSearchCafeBinding>() {
         searchCafeAdapter.loadStateFlow
           .distinctUntilChangedBy { it.refresh }
           .collect { loadStates ->
-            if (loadStates.source.refresh is LoadState.NotLoading && loadStates.append.endOfPaginationReached && searchCafeAdapter.itemCount < 1
-            ) {
-              binding.apply {
-                tvNoRecentSearches.visibility = View.VISIBLE
-                binding.rvSearchCafe.visibility = View.GONE
-              }
-            } else {
-              binding.apply {
-                tvNoRecentSearches.visibility = View.GONE
-                binding.rvSearchCafe.visibility = View.VISIBLE
-              }
+            val isListEmpty = loadStates.source.refresh is LoadState.NotLoading &&
+              loadStates.append.endOfPaginationReached &&
+              searchCafeAdapter.itemCount < 1
+            val isSearchQueryEmpty = searchCafeViewModel.searchQuery.value.isEmpty()
+
+            binding.apply {
+              tvNoRecentSearches.visibility = if (isListEmpty && isSearchQueryEmpty) View.VISIBLE else View.GONE
+              tvNoSearchResults.visibility = if (isListEmpty && !isSearchQueryEmpty) View.VISIBLE else View.GONE
+              rvSearchCafe.visibility = if (isListEmpty) View.GONE else View.VISIBLE
             }
           }
       }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/search/SearchFragment.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/search/SearchFragment.kt
@@ -38,6 +38,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import us.wedemy.eggeum.android.common.extension.repeatOnStarted
 import us.wedemy.eggeum.android.common.extension.safeNavigate
 import us.wedemy.eggeum.android.common.base.BaseFragment
@@ -214,6 +215,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(), OnMapReadyCallback
     fusedLocationClient.lastLocation.addOnSuccessListener { location ->
       val cameraUpdate = CameraUpdate.scrollTo(LatLng(location.latitude, location.longitude))
       naverMap?.moveCamera(cameraUpdate)
+      Timber.d("Current Location ${location.latitude} ${location.longitude}")
 
       searchViewModel.setCurrentLocation(location.latitude, location.longitude)
     }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/search/SearchFragment.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/ui/search/SearchFragment.kt
@@ -122,7 +122,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(), OnMapReadyCallback
     }
 
     binding.cvSearchCafe.setOnClickListener {
-      val action = SearchFragmentDirections.actionFragmentSearchToFragmentSearchCafeFragment()
+      val action = SearchFragmentDirections.actionFragmentSearchToFragmentSearchCafeFragment(searchViewModel.currentLocation.value)
       findNavController().safeNavigate(action)
     }
   }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/NoticeViewModel.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/NoticeViewModel.kt
@@ -58,6 +58,6 @@ class NoticeViewModel @Inject constructor(
 
   private companion object {
     private const val KEY_SEARCH_KEYWORD = "search_keyword"
-    private const val SEARCH_TIME_DELAY = 500L
+    private const val SEARCH_TIME_DELAY = 300L
   }
 }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/SearchCafeViewModel.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/SearchCafeViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.naver.maps.geometry.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,6 +29,7 @@ import us.wedemy.eggeum.android.domain.usecase.DeleteRecentSearchPlaceUseCase
 import us.wedemy.eggeum.android.domain.usecase.GetSearchPlaceListUseCase
 import us.wedemy.eggeum.android.domain.usecase.InsertRecentSearchPlaceUseCase
 
+// TODO 검색 결과 아이템과 최근 검색 결과 아이템의 디자인이 달라야함
 @HiltViewModel
 class SearchCafeViewModel @Inject constructor(
   getSearchPlaceListUseCase: GetSearchPlaceListUseCase,
@@ -39,6 +41,9 @@ class SearchCafeViewModel @Inject constructor(
     savedStateHandle.getMutableStateFlow(KEY_CAFE_NAME, "")
   val searchQuery = _searchQuery.asStateFlow()
 
+  private val currentLocation: LatLng =
+    requireNotNull(savedStateHandle.get<LatLng>(KEY_CURRENT_LOCATION)) { "currentLocation is required." }
+
   @OptIn(FlowPreview::class)
   val debouncedSearchQuery: Flow<String?> = searchQuery
     .debounce(SEARCH_TIME_DELAY)
@@ -47,7 +52,12 @@ class SearchCafeViewModel @Inject constructor(
   @OptIn(ExperimentalCoroutinesApi::class)
   val searchPlaceList: Flow<PagingData<PlaceEntity>> =
     debouncedSearchQuery.flatMapLatest { query ->
-      getSearchPlaceListUseCase(query = query)
+      getSearchPlaceListUseCase(
+        query = query,
+        distance = 2500.0,
+        latitude = currentLocation.latitude,
+        longitude = currentLocation.longitude,
+      )
     }.cachedIn(viewModelScope)
 
   fun setSearchQuery(query: String) {
@@ -69,5 +79,6 @@ class SearchCafeViewModel @Inject constructor(
   private companion object {
     private const val KEY_CAFE_NAME = "cafe_name"
     private const val SEARCH_TIME_DELAY = 300L
+    private const val KEY_CURRENT_LOCATION = "current_location"
   }
 }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/SearchCafeViewModel.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/SearchCafeViewModel.kt
@@ -47,7 +47,7 @@ class SearchCafeViewModel @Inject constructor(
   @OptIn(ExperimentalCoroutinesApi::class)
   val searchPlaceList: Flow<PagingData<PlaceEntity>> =
     debouncedSearchQuery.flatMapLatest { query ->
-      getSearchPlaceListUseCase(query)
+      getSearchPlaceListUseCase(query = query)
     }.cachedIn(viewModelScope)
 
   fun setSearchQuery(query: String) {
@@ -68,6 +68,6 @@ class SearchCafeViewModel @Inject constructor(
 
   private companion object {
     private const val KEY_CAFE_NAME = "cafe_name"
-    private const val SEARCH_TIME_DELAY = 500L
+    private const val SEARCH_TIME_DELAY = 300L
   }
 }

--- a/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/SearchViewModel.kt
+++ b/main/src/main/kotlin/us/wedemy/eggeum/android/main/viewmodel/SearchViewModel.kt
@@ -28,13 +28,14 @@ class SearchViewModel @Inject constructor(
   private val getPlaceListUseCase: GetPlaceListUseCase,
 ) : ViewModel() {
   private val _currentLocation = MutableStateFlow(LatLng(-1.0, -1.0))
+  val currentLocation: StateFlow<LatLng> = _currentLocation.asStateFlow()
 
   fun setCurrentLocation(latitude: Double, longitude: Double) {
     _currentLocation.value = LatLng(latitude, longitude)
   }
 
   // TODO 맵 zoom level, 내 위치가 변하면 값이 갱신 되어야 함
-  // 반경 1km 내에 위치한 장소에 마커가 찍히도록
+  // 반경 2.5km 내에 위치한 장소에 마커가 찍히도록
   @OptIn(ExperimentalCoroutinesApi::class)
   val placeList = _currentLocation
     .filter { location ->

--- a/main/src/main/res/layout/fragment_search_cafe.xml
+++ b/main/src/main/res/layout/fragment_search_cafe.xml
@@ -55,6 +55,20 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/cv_search_cafe" />
 
+  <TextView
+    android:id="@+id/tv_no_search_results"
+    style="@style/TextMRegular"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="112dp"
+    android:gravity="center_horizontal"
+    android:text="@string/no_search_results"
+    android:textColor="@color/gray_500"
+    android:visibility="gone"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/cv_search_cafe" />
+
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/rv_search_cafe"
     android:layout_width="0dp"

--- a/main/src/main/res/layout/fragment_search_cafe.xml
+++ b/main/src/main/res/layout/fragment_search_cafe.xml
@@ -67,6 +67,6 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@id/cv_search_cafe"
-    tools:listitem="@layout/item_search_cafe_location" />
+    tools:listitem="@layout/item_recent_search_cafe_result" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/main/src/main/res/layout/item_recent_search_cafe_result.xml
+++ b/main/src/main/res/layout/item_recent_search_cafe_result.xml
@@ -14,7 +14,7 @@
   tools:ignore="HardcodedText">
 
   <ImageView
-    android:id="@+id/iv_cafe_search_location"
+    android:id="@+id/iv_recent_search_cafe"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginStart="16dp"
@@ -25,7 +25,7 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <TextView
-    android:id="@+id/tv_cafe_search_location"
+    android:id="@+id/tv_recent_search_cafe_name"
     style="@style/TextLMedium"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
@@ -35,13 +35,13 @@
     android:maxLines="1"
     android:textColor="@color/gray_900"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/iv_cafe_search_location_delete"
-    app:layout_constraintStart_toEndOf="@id/iv_cafe_search_location"
+    app:layout_constraintEnd_toStartOf="@id/iv_recent_search_cafe_delete"
+    app:layout_constraintStart_toEndOf="@id/iv_recent_search_cafe"
     app:layout_constraintTop_toTopOf="parent"
     tools:text="스타벅스 강남역신분당역사점" />
 
   <ImageView
-    android:id="@+id/iv_cafe_search_location_delete"
+    android:id="@+id/iv_recent_search_cafe_delete"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginEnd="16dp"

--- a/main/src/main/res/layout/item_search_cafe_result.xml
+++ b/main/src/main/res/layout/item_search_cafe_result.xml
@@ -14,7 +14,7 @@
   tools:ignore="HardcodedText">
 
   <ImageView
-    android:id="@+id/iv_cafe_search_result"
+    android:id="@+id/iv_search_cafe_result"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginStart="16dp"
@@ -25,7 +25,7 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <TextView
-    android:id="@+id/tv_cafe_search_result_name"
+    android:id="@+id/tv_search_cafe_result_name"
     style="@style/TextLMedium"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
@@ -35,24 +35,24 @@
     android:maxLines="1"
     android:textColor="@color/gray_900"
     app:layout_constraintEnd_toStartOf="@+id/iv_cafe_search_result_arrow"
-    app:layout_constraintStart_toEndOf="@id/iv_cafe_search_result"
+    app:layout_constraintStart_toEndOf="@id/iv_search_cafe_result"
     app:layout_constraintTop_toTopOf="parent"
     tools:text="스타벅스 강남역신분당역사점" />
 
   <TextView
-    android:id="@+id/tv_cafe_search_result_address"
+    android:id="@+id/tv_search_cafe_result_address"
     style="@style/TextXsRegular"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
-    app:layout_constraintTop_toBottomOf="@id/tv_cafe_search_result_name"
+    app:layout_constraintTop_toBottomOf="@id/tv_search_cafe_result_name"
     android:ellipsize="end"
     android:maxLines="1"
     android:textColor="@color/gray_400"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@+id/iv_cafe_search_result_arrow"
-    app:layout_constraintStart_toEndOf="@id/iv_cafe_search_result"
+    app:layout_constraintStart_toEndOf="@id/iv_search_cafe_result"
     tools:text="서울 특별시 강남구 강남대로 396" />
 
   <ImageView

--- a/main/src/main/res/navigation/nav_main.xml
+++ b/main/src/main/res/navigation/nav_main.xml
@@ -130,6 +130,10 @@
       app:popEnterAnim="@anim/nav_default_pop_enter_anim"
       app:popExitAnim="@anim/nav_default_pop_exit_anim" />
 
+    <argument
+      android:name="current_location"
+      app:argType="com.naver.maps.geometry.LatLng" />
+
   </fragment>
 
   <fragment

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
   <string name="image_index"><font color="#ffffff">5</font><font color="#6b7280">/25</font></string>
   <string name="proposal_info_edit">정보 수정 제안</string>
   <string name="no_recent_searches">최근 검색어가 없습니다.</string>
+  <string name="no_search_results">검색 결과가 존재하지 않습니다.</string>
 
   <!--  MyAccount-->
   <string name="edit_my_info">내 정보 수정</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -7,18 +7,17 @@
 
 <resources>
   <!--  Home-->
-
+  <string name="home">홈</string>
+  <string name="new_cafe">신규 카페</string>
+  <string name="check_new_cafe">새롭게 추가된 카페를 확인해보세요.</string>
+  <string name="cafe">카페</string>
+  <string name="study_cafe">스터디 카페</string>
+  <string name="study_room">스터디 룸</string>
 
   <!--  Search-->
   <string name="my_account">내 계정</string>
   <string name="search">검색</string>
-  <string name="home">홈</string>
-  <string name="new_cafe">신규 카페</string>
-  <string name="check_new_cafe">새롭게 추가된 카페를 확인해보세요.</string>
   <string name="search_cafe">카페 검색</string>
-  <string name="cafe">카페</string>
-  <string name="study_cafe">스터디 카페</string>
-  <string name="study_room">스터디 룸</string>
   <string name="location_permission_educational_message">지도 사용을 위해 위치 권한을 허용해주세요.(필수권한)</string>
   <string name="check">확인</string>
   <string name="cancel">취소</string>
@@ -47,6 +46,7 @@
   <string name="cafe_image_report">사진 신고하기</string>
   <string name="image_index"><font color="#ffffff">5</font><font color="#6b7280">/25</font></string>
   <string name="proposal_info_edit">정보 수정 제안</string>
+  <string name="no_recent_searches">최근 검색어가 없습니다.</string>
 
   <!--  MyAccount-->
   <string name="edit_my_info">내 정보 수정</string>
@@ -101,7 +101,6 @@
   <string name="pornographic_or_sexual_content">포르노 또는 성적인 콘텐츠</string>
   <string name="spam">스팸</string>
   <string name="copyright_or_legal_matter">저작권 또는 법적 문제</string>
-  <string name="no_recent_searches">최근 검색어가 없습니다.</string>
   <string name="invalid_address">올바른 주소가 아닙니다</string>
   <string name="withdraw_complete">회원 탈퇴가 완료되었습니다.</string>
   <string name="logout_complete">로그아웃이 완료되었습니다.</string>

--- a/onboard/src/main/AndroidManifest.xml
+++ b/onboard/src/main/AndroidManifest.xml
@@ -8,11 +8,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
+
     <activity
       android:name=".ui.OnboardActivity"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:theme="@style/Theme.Eggeum.Onboard"
       android:windowSoftInputMode="adjustPan" />
+
   </application>
 
 </manifest>

--- a/register-cafe/src/main/AndroidManifest.xml
+++ b/register-cafe/src/main/AndroidManifest.xml
@@ -8,9 +8,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
+
     <activity
       android:name=".ui.RegisterCafeActivity"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:theme="@style/Theme.Eggeum.RegisterCafe"
       android:windowSoftInputMode="adjustPan" />
 

--- a/update-cafe/src/main/AndroidManifest.xml
+++ b/update-cafe/src/main/AndroidManifest.xml
@@ -7,12 +7,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
+
     <activity
       android:name=".ui.UpdateCafeActivity"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:theme="@style/Theme.Eggeum.UpdateCafe"
-      android:windowSoftInputMode="adjustPan">
-    </activity>
+      android:windowSoftInputMode="adjustPan" />
+
   </application>
 
 </manifest>


### PR DESCRIPTION
- Debounce 시간 축소(0.5초 -> 0.3초)
- 장소 검색시 현재 사용자 위치 기준 2.5km 이내에 장소만 결과로 출력되도록 설정
- 검색을 통한 결과, 최근 검색 목록 리스트 아이템 분리(검색 결과의 경우 X 가 아닌 > 아이콘이 출력되며, 하단의 주소도 표기됨)
- 검색 결과가 존재하지 않을때, 최근 검색 목록과 검색 결과의 케이스를 분리 
- 화면 세로 고정
- 사용하지 않는 함수 제거 